### PR TITLE
fixed typo "downlaod" above the iCloud drive link 

### DIFF
--- a/docs/Available-OS/6.AOSP.md
+++ b/docs/Available-OS/6.AOSP.md
@@ -11,7 +11,7 @@ title: AOSP
 
 AOSP 14 for Fydetab Duo, packaged based on the factory default AOSP release from Rockchip RK3588 Android SDK.
 
-### Downlaod 
+### Download
 
 - [☁️ iCloud Drive](https://www.icloud.com/iclouddrive/087z2WV7MMw_UHB4PkyXyIVWw#fydetab-android-r15)
 


### PR DESCRIPTION
So before the page had the typo "downlaod" so i fixed it to "download" 