### PR TITLE
Fix the link to the available-os page

### DIFF
--- a/docs/1.intro.md
+++ b/docs/1.intro.md
@@ -13,7 +13,7 @@ Fydetab Duo is the world's first consumer-grade "Google-optional" Chromium OS ta
 - Powered by FydeOS - a proven Chromium OS distro that has been maintained for over 6 years and has millions of users worldwide.
 - An open-source platform with an excellent opportunity to understand what is happening beneath the surface and customise and personalise your experience by booting an operating system built from source code.
 - Fydetab Duo is designed by Fyde Innovations, the company behind FydeOS - a proven alternative approach to chromeOS, with or without Google.
-- Fydetab Duo is designed to run FydeOS by default. However, you may also boot and run other [open-source operating systems](/category/Available-OS).
+- Fydetab Duo is designed to run FydeOS by default. However, you may also boot and run other [open-source operating systems](/category/-available-os).
 
 ## Community Projects
 - [Fydetab Duo wiki by DroidMaster](https://github.com/LinuxDroidMaster/Fydetab-Duo-DroidMaster-wiki)


### PR DESCRIPTION
Clicking this link currently results in a page not found error