### PR TITLE
Update UEFI sd card slot note

### DIFF
--- a/docs/Available-OS/ArchLinux/2.Installation.md
+++ b/docs/Available-OS/ArchLinux/2.Installation.md
@@ -13,7 +13,7 @@ import TabItem from '@theme/TabItem';
 3. Insert the SD card into the Fydetab Duo.
 
    :::note
-   Ensure the SD card slot is slightly open to boot from UEFI firmware.
+   For images prior to 2025-06-24: Ensure the SD card slot is slightly open to boot from UEFI firmware. This is not required for U-Boot images.
    :::
 
 ### Install to eMMC


### PR DESCRIPTION
Updates Arch Linux installation doc to include open sd card slot note not required for newer, U-Boot based images:

<img width="2560" height="1592" alt="image" src="https://github.com/user-attachments/assets/fed84df3-30a0-45c8-8f47-981af318e081" />
